### PR TITLE
Groupsのルールを作成

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -93,7 +93,7 @@ service cloud.firestore {
     match /Groups/{groupID} {
       // UserがgroupIDに所属しているか判定
       function isBelongingGroup(groupID) {
-        return printRequest() && exists(/databases/$(database)/documents/Users/$(request.auth.uid)/Groups/$(groupID))
+        return exists(/databases/$(database)/documents/Users/$(request.auth.uid)/Groups/$(groupID))
       }
 
       // Groupのスキーマ検証

--- a/firestore.rules
+++ b/firestore.rules
@@ -56,7 +56,7 @@ service cloud.firestore {
       && request.resource.data.AgreementDate < request.time // AgreementDateがrequest.time以前(チェックする→送信の流れなので必ず少し前になる)
       && request.resource.data.RegistrationDate == request.time // 作成時刻はサーバタイムスタンプの値と一致
 
-      // User情報を更新できるのは自分だけ、またRegistrationDateは更新できない
+      // Users情報を更新できるのは自分だけ、またRegistrationDateは更新できない
       allow update: if isUserAuthenticated(userID) // ログインとUserIDの判定
       && isValidUser(request.resource.data) // スキーマ検証
       // 以下データのバリデーション
@@ -64,7 +64,7 @@ service cloud.firestore {
       && request.resource.data.AgreementDate < request.time // AgreementDateがrequest.time以前(チェックする→送信の流れなので必ず少し前になる)
       && request.resource.data.RegistrationDate == resource.data.RegistrationDate; // RegistrationDateは更新されていない
 
-      // User情報を削除できるのは自分だけ
+      // Users情報を削除できるのは自分だけ
       allow delete: if isUserAuthenticated(userID);
 
       // Users以下のGroupsに関するRule
@@ -87,6 +87,32 @@ service cloud.firestore {
         // Groups情報を削除できるのは自分だけ
         allow delete: if isUserAuthenticated(userID);
       }
+    }
+
+    // Groupsに関するRule
+    match /Groups/{groupID} {
+      // UserがgroupIDに所属しているか判定
+      function isBelongingGroup(groupID) {
+        return printRequest() && exists(/databases/$(database)/documents/Users/$(request.auth.uid)/Groups/$(groupID))
+      }
+
+      // Groupのスキーマ検証
+      function isValidGroup(group) {
+        return group.size() == 3 // 要素は三つ
+        && 'GroupName' in group && group.GroupName is string // GroupNameがあって、string
+        && 'GroupNameEng' in group && group.GroupNameEng is string // GroupNameEngがあって、string
+        && 'GroupPassword' in group && group.GroupPassword is string // GroupPasswordがあって、string
+      }
+
+      // Groupsの情報はログインしていれば誰でも読み込める
+      allow read: if isAuthenticated();
+
+      // Groups情報はグループに所属していれば編集できる
+      allow update: if isAuthenticated() // ログインしてるかチェック
+      && isBelongingGroup(groupID) // 所属しているかチェック
+      && isValidGroup(request.resource.data) // スキーマ検証
+
+      // Groups情報は現段階では作成、削除ができない
     }
   }
 }

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -8,6 +8,10 @@ function usergroupsRef(db: firebase.firestore.Firestore, userName: string): fire
   return db.collection(`Users/${userName}/Groups`);
 }
 
+function groupsRef(db: firebase.firestore.Firestore): firebase.firestore.CollectionReference {
+  return db.collection(`Groups`);
+}
+
 // テスト用のクラス、誤った値を入れられるように型を少し実際とは変えています
 class User {
   UserName: string | number;
@@ -81,6 +85,31 @@ function correctUserGroup(): UserGroup {
   );
 }
 
+class Group {
+  GroupName: string | number;
+  GroupNameEng: string | number;
+  GroupPassword: string | number;
+
+  constructor(
+    groupName: string,
+    groupNameEng: string,
+    groupPassword: string
+  ) {
+    this.GroupName = groupName;
+    this.GroupNameEng = groupNameEng;
+    this.GroupPassword = groupPassword;
+  }
+}
+
+function correctGroup() {
+  return new Group(
+    'kpo',
+    'kpo',
+    '12345678'
+  );
+}
+
+
 class AuthUser {
   uid: string;
 
@@ -93,14 +122,17 @@ function authedApp(auth: AuthUser, projectId: string): firebase.firestore.Firest
   return firebase.initializeTestApp({ projectId: projectId, auth: auth }).firestore();
 }
 
-// function adminApp(): firebase.firestore.Firestore {
-//   return firebase.initializeAdminApp({ projectId: testName }).firestore();
-// }
+function adminApp(projectId: string): firebase.firestore.Firestore {
+  return firebase.initializeAdminApp({ projectId: projectId }).firestore();
+}
 
 export {
   usersRef,
   usergroupsRef,
+  groupsRef,
   correctUser,
   correctUserGroup,
-  authedApp
+  correctGroup,
+  authedApp,
+  adminApp
 }

--- a/test/rules_groups.test.ts
+++ b/test/rules_groups.test.ts
@@ -1,0 +1,164 @@
+import * as firebase from '@firebase/testing';
+import * as fs from 'fs';
+import {
+  usersRef,
+  usergroupsRef,
+  correctUser,
+  correctUserGroup,
+  groupsRef,
+  correctGroup,
+  authedApp,
+  adminApp,
+} from './lib/utils';
+
+const rulesFilePath = 'firestore.rules';
+const testName = 'firesbase-kpoapp-groups';
+
+describe(testName, () => {
+  // はじめに１度ルールを読み込ませる
+  beforeAll(async () => {
+    await firebase.loadFirestoreRules({
+      projectId: testName,
+      rules: fs.readFileSync(rulesFilePath, 'utf8'),
+    });
+  });
+
+  // 開始前に毎回ユーザを作り所属グループも追加する
+  beforeEach(async () => {
+    const db = authedApp({ uid: 'atsutomo' }, testName);
+    const profile = usersRef(db).doc('atsutomo');
+    const user = correctUser();
+    await profile.set({ ...user });
+    const usergroup = usergroupsRef(db, 'atsutomo').doc('kpo');
+    const group = correctUserGroup();
+    await usergroup.set({ ...group });
+  });
+
+  // test毎にデータをクリアする
+  afterEach(async () => {
+    await firebase.clearFirestoreData({ projectId: testName });
+  });
+
+  // 全テスト終了後に作成したアプリを全消去
+  afterAll(async () => {
+    await Promise.all(firebase.apps().map((app) => app.delete()));
+  });
+
+  // Groupsのテスト
+  describe('コレクションGroupsのテスト', () => {
+    describe('read', () => {
+      test('ログインしていないユーザはreadできない', async () => {
+        const db = authedApp(null, testName);
+        const groups = groupsRef(db).doc('kpo');
+        await firebase.assertFails(groups.get());
+      });
+
+      test('ログインしていればReadできる', async () => {
+        const db = authedApp({ uid: 'atsutomo' }, testName);
+        const groups = groupsRef(db).doc('kpo');
+        await firebase.assertSucceeds(groups.get());
+      });
+    });
+
+    describe('create', () => {
+      test('作成はできない', async () => {
+        const db = authedApp({ uid: 'atsutomo' }, testName);
+        const groupref = groupsRef(db).doc('kpo');
+        const group = correctGroup();
+        await firebase.assertFails(groupref.set({ ...group }));
+      });
+    });
+
+    describe('update', () => {
+      // 開始前にgroupの情報作っておく
+      beforeEach(async () => {
+        const admin = adminApp(testName);
+        const adminRef = groupsRef(admin).doc('kpo');
+        const group = correctGroup();
+        await firebase.assertSucceeds(adminRef.set({ ...group }));
+      });
+
+      describe('成功例', () => {
+        test('ログインいるユーザは自分が所属してるグループ情報なら更新できる', async () => {
+          const db = authedApp({ uid: 'atsutomo' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+          group.GroupName = 'kpo2';
+          await firebase.assertSucceeds(normalRef.set({ ...group }, { merge: true }));
+        });
+      });
+
+      describe('ログイン関係で失敗', () => {
+        test('ログインいないユーザはグループ情報を更新できない', async () => {
+          const anonymusUser = authedApp(null, testName);
+          const anonymus = groupsRef(anonymusUser).doc('kpo');
+          const group = correctGroup();
+          group.GroupName = 'kpo2';
+          await firebase.assertFails(anonymus.set({ ...group }, { merge: true }));
+        });
+
+        test('ログインしててもユーザIDが違うと所属グループ情報を更新できない', async () => {
+          const db = authedApp({ uid: 'tabata' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+          group.GroupName = 'kpo2';
+          await firebase.assertFails(normalRef.set({ ...group }, { merge: true }));
+        });
+      });
+
+      describe('スキーマ検証で失敗', () => {
+        test('スキーマ数が3個じゃないとだめ', async () => {
+          const db = authedApp({ uid: 'atsutomo' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+
+          // 少ない時は{merge: true}がないとだめ
+          const { GroupName, ...restGroup } = group;
+          await firebase.assertFails(normalRef.set({ ...restGroup }));
+
+          // 多い場合は{merge: true}があってもだめ
+          group.GroupName = 'kpo2';
+          await firebase.assertFails(
+            normalRef.set({ ...group, para1: 10, para2: 20 }, { merge: true })
+          );
+        });
+
+        test('GroupNameがstringじゃないとダメ', async () => {
+          const db = authedApp({ uid: 'atsutomo' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+          group.GroupName = 111;
+          await firebase.assertFails(normalRef.set({ ...group }, { merge: true }));
+        });
+
+        test('GroupNameEngがstringじゃないとダメ', async () => {
+          const db = authedApp({ uid: 'atsutomo' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+          group.GroupNameEng = 111;
+          await firebase.assertFails(normalRef.set({ ...group }, { merge: true }));
+        });
+
+        test('GroupPasswordがstringじゃないとダメ', async () => {
+          const db = authedApp({ uid: 'atsutomo' }, testName);
+          const normalRef = groupsRef(db).doc('kpo');
+          const group = correctGroup();
+          group.GroupPassword = 111;
+          await firebase.assertFails(normalRef.set({ ...group }, { merge: true }));
+        });
+      });
+    });
+
+    describe('delete', () => {
+      test('削除はできない', async () => {
+        const admin = adminApp(testName);
+        const adminRef = groupsRef(admin).doc('kpo');
+        const group = correctGroup();
+        await firebase.assertSucceeds(adminRef.set({ ...group }));
+        const authedUser = authedApp({ uid: 'atsutomo' }, testName);
+        const authed = groupsRef(authedUser).doc('kpo');
+        await firebase.assertFails(authed.delete());
+      });
+    });
+  });
+});

--- a/test/rules_usergroups.test.ts
+++ b/test/rules_usergroups.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { usersRef, usergroupsRef, correctUser, correctUserGroup, authedApp } from './lib/utils';
 
 const rulesFilePath = 'firestore.rules';
-const testName = 'firesbase-kpoapp-1';
+const testName = 'firesbase-kpoapp-usergroups';
 
 describe(testName, () => {
   // はじめに１度ルールを読み込ませる
@@ -229,7 +229,7 @@ describe(testName, () => {
           await firebase.assertFails(authed.set({ ...restGroup }, { merge: true }));
         });
 
-        test('GroupNameがstringじゃないとダメ', async () => {
+        test('GroupNameEngがstringじゃないとダメ', async () => {
           const authedUser = authedApp({ uid: 'atsutomo' }, testName);
           const authed = usergroupsRef(authedUser, 'atsutomo').doc('kpo');
           const group = correctUserGroup();

--- a/test/rules_users.test.ts
+++ b/test/rules_users.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { usersRef, correctUser, authedApp } from './lib/utils';
 
 const rulesFilePath = 'firestore.rules';
-const testName = 'firesbase-kpoapp-2';
+const testName = 'firesbase-kpoapp-users';
 
 describe(testName, () => {
   // はじめに１度ルールを読み込ませる


### PR DESCRIPTION
## 概要
Groupsコレクションへのルールを作成した

## ルール
- 作成、削除は現時点ではできない
- 参照はログインしていれば誰でもできる→検索機能のため
- 更新はログインしていて所属している人ならできる→existsでやっているが`CustomClaim`の方がいいのかな